### PR TITLE
Patchin ui.menu for identify EEUITweaks over LeUI

### DIFF
--- a/SubtleD_Spell_Tweaks/lib/semi_spont/B3Identify.tph
+++ b/SubtleD_Spell_Tweaks/lib/semi_spont/B3Identify.tph
@@ -127,16 +127,17 @@ Infinity_DoFile("B3CONRED")
 
 			PATCH_IF MOD_IS_INSTALLED ~LeUI.tp2~ ~0~ OR MOD_IS_INSTALLED ~LeUI-BG1EE.tp2~ ~0~ OR MOD_IS_INSTALLED ~LeUI-SoD.tp2~ ~0~ BEGIN
 
-				LPF REPLACE_MULTILINE INT_VAR num = 1 STR_VAR pattern = ~		showMageMemorizationFlash = false
-		setMageBookLevel(1, true)~ string = ~
+				LPF REPLACE_MULTILINE INT_VAR num = 1 STR_VAR pattern =
+~\([ 	]*showMageMemorizationFlash = false\)\(\(
+[ 	]*selectedSpell = nil\)\|\(
+[ 	]*setMageBookLevel(1, true)\)\)~ string = ~
 		-- B3ContingencyRedirect Edit Start
 
 		if B3ContingencyRedirect_MageDoRedirect() then return end
 
 		-- B3ContingencyRedirect Edit End
 
-		showMageMemorizationFlash = false
-		setMageBookLevel(1, true)~
+\1\2~
 				END
 
 			END ELSE BEGIN


### PR DESCRIPTION
The current ui.menu patching for identify works when LeUI is installed alone.

When EEUITweaks component "Spell Books -> Kilivitz''s Classic Spellbooks" is installed over LeUI it fails (finds no match)
(this one : https://forums.beamdog.com/discussion/63434/mod-classic-spellbook-for-bg-ee-sod-and-bg2-ee)

This change *should* allow to patch both version, but the regex is a little more involved.

I didn't check for the other spell book mod in EEUITweaks (lefreut's Inscribed Arcana) 